### PR TITLE
Fix mingw32 build

### DIFF
--- a/include/relic_alloc.h
+++ b/include/relic_alloc.h
@@ -31,7 +31,7 @@
 
 #include "relic_conf.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 #include <malloc.h>
 

--- a/src/rand/relic_rand_core.c
+++ b/src/rand/relic_rand_core.c
@@ -54,7 +54,12 @@
 #undef DOUBLE
 
 #include <windows.h>
+
+#ifdef __MINGW32__
+#include <wincrypt.h>
+#else
 #include <Wincrypt.h>
+#endif
 
 #elif SEED == RDRND
 


### PR DESCRIPTION
Mingw32 build failed because it was not able to find alloca.h and Wincrypt.h.

This patch points to the right malloc.h and wincrypt.h files and builds succeeds.